### PR TITLE
Use rclcpp::ServicesQoS instead of rmw_qos_profile_t

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
@@ -216,8 +216,7 @@ inline RosServiceNode<T>::ServiceClientInstance::ServiceClientInstance(
       node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
   callback_executor.add_callback_group(callback_group, node->get_node_base_interface());
 
-  service_client = node->create_client<T>(service_name, rmw_qos_profile_services_default,
-                                          callback_group);
+  service_client = node->create_client<T>(service_name, rclcpp::ServicesQoS(), callback_group);
 }
 
 template <class T>

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_service_server_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_service_server_node.hpp
@@ -165,7 +165,7 @@ inline bool RosServiceServerNode<T>::createService(const std::string& service_na
              typename Response::SharedPtr response) -> void {
         serviceCallback(request, response);
       },
-      rmw_qos_profile_services_default,
+      rclcpp::ServicesQoS(),
       callback_group_);
   RCLCPP_INFO(node_->get_logger(), "Node [%s] created service server [%s]", name().c_str(),
               service_name.c_str());


### PR DESCRIPTION
to suppress deprecated warning in ROS 2 jazzy